### PR TITLE
concatenation bug fixed

### DIFF
--- a/cpp/strings_concatenation.cpp
+++ b/cpp/strings_concatenation.cpp
@@ -20,7 +20,7 @@ size_t StrSize(const Head& head, Tail const&... tail){
 
 template <class Head>
 void StrAppend(std::string& out, const Head& head){
-  out = head;
+  out += head;
 }
 
 template <class Head, class... Args>


### PR DESCRIPTION
StrCat("abc", "def") returnd "def", rather than "abcdef".

StrCat failed due to the miss of character '+'.
